### PR TITLE
Basic idealized case support

### DIFF
--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -241,6 +241,9 @@ class Calc(object):
             try:
                 time_obj = netCDF4.MFTime(nc.variables['time'])
             except ValueError:
+                warnings.warn('Unsupported calendar attribute provided: %s.'
+                              ' Defaulting to 360_day calendar type.'
+                              % nc.variables['time'].calendar, RuntimeWarning)
                 nc.variables['time'].calendar = '360_day'
                 time_obj = netCDF4.MFTime(nc.variables['time'])
             inds, time = _get_time(
@@ -506,8 +509,9 @@ class Calc(object):
             try:        
                 time = netCDF4.MFTime(nc.variables['time'])
             except ValueError:
-                warnings.warn('Unsupported calendar attribute provided: %s. Defaulting to 360_day calendar type.' % nc.variables['time'].calendar, RuntimeWarning) 
-    #            print "Unsupported calendar attribute provided: %s. Defaulting to 360_day calendar type." % nc.variables['time'].calendar
+                warnings.warn('Unsupported calendar attribute provided: %s.'
+                              ' Defaulting to 360_day calendar type.'
+                              % nc.variables['time'].calendar, RuntimeWarning) 
                 nc.variables['time'].calendar = '360_day'
                 time = netCDF4.MFTime(nc.variables['time'])
 

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -9,7 +9,6 @@ import warnings
 
 import netCDF4
 import numpy as np
-import xray
 
 from . import Constant, Var, Region
 from .io import (_data_in_label, _data_out_label, _ens_label, _get_time,
@@ -765,7 +764,6 @@ class Calc(object):
              scratch=True, archive=False):
         """Save aospy data to data_out attr and to an external file."""
         self._update_data_out(data, dtype_out_time)
-        print self._to_DataArray(data)
         if scratch:
             self._save_to_scratch(data, dtype_out_time,
                                   dtype_out_vert=dtype_out_vert)
@@ -815,16 +813,3 @@ class Calc(object):
         if plot_units:
             data = self.var.to_plot_units(data, vert_int=dtype_out_vert)
         return data
-
-    def _to_DataArray(self, data):
-        """
-        Converts a Calc instance to an xray DataArray.  Pulls grid information from instance.
-        """
-        
-        if not self.pressure:
-            print data.shape
-            print self.lat
-            print self.lon
-            return xray.DataArray(data, coords=[self.lat, self.lon], dims=['lat','lon'], encoding={'lat' : 'f8', 'lon' : 'f8'})
-        else:
-            return None

--- a/aospy/io.py
+++ b/aospy/io.py
@@ -4,7 +4,6 @@ import string
 import subprocess
 import numpy as np
 import netCDF4
-import warnings
 
 def to_dup_list(x, n, single_to_list=True):
     """

--- a/aospy/io.py
+++ b/aospy/io.py
@@ -4,7 +4,7 @@ import string
 import subprocess
 import numpy as np
 import netCDF4
-
+import warnings
 
 def to_dup_list(x, n, single_to_list=True):
     """
@@ -167,10 +167,7 @@ def _get_time(time, units, calendar, start_yr, end_yr, months, indices=False):
                     the time array itself at those time indices.
     :type indices: bool
     """
-    try:
-        dates = netCDF4.num2date(time[:], units, calendar.lower())
-    except:
-        dates = netCDF4.num2date(time[:], units, '360_day')    
+    dates = netCDF4.num2date(time[:], units, calendar.lower())
     inds = [i for i, date in enumerate(dates) if (date.month in months) and
             (date.year in range(start_yr, end_yr+1))]
     if indices == 'only':

--- a/aospy/io.py
+++ b/aospy/io.py
@@ -167,7 +167,10 @@ def _get_time(time, units, calendar, start_yr, end_yr, months, indices=False):
                     the time array itself at those time indices.
     :type indices: bool
     """
-    dates = netCDF4.num2date(time[:], units, calendar.lower())
+    try:
+        dates = netCDF4.num2date(time[:], units, calendar.lower())
+    except:
+        dates = netCDF4.num2date(time[:], units, '360_day')    
     inds = [i for i, date in enumerate(dates) if (date.month in months) and
             (date.year in range(start_yr, end_yr+1))]
     if indices == 'only':

--- a/aospy/model.py
+++ b/aospy/model.py
@@ -157,6 +157,6 @@ class Model(object):
         self._set_sfc_area()
         try:
             self.levs_thick = level_thickness(self.level)
-        except AttributeError:
+        except (AttributeError, TypeError):
             self.levs_thick = None
         self.grid_data_is_set = True


### PR DESCRIPTION
It appears the bare minimum changes required to read in an idealized case are:
1. Exception handling for 'NO_CALENDAR' specifications in netCDF file metadata.  A solution is to default to a '360_day' calendar type.  Without any further modifications this is somewhat dangerous, since one can then make monthly or seasonal climatologies (that are meaningless).  However, implementing non-standard calendar support is likely a bit over our heads at the moment (at the very least outside the scope of aospy; see numpy/numpy#6207, xray/xray#126, pydata/pandas#7307).  The pandas issue link interestingly explains why datetime64 (by default) can only support going back to 1678. 
2. Exception handling to allow a Model / Run to be read in without a set of interpolated pressure levels.  In other words, allow for a case which _only_ uses the model vertical coordinates. 

Past that, along with these changes, if one uses the one_dir file read in mode, things work reasonably well.  For example this is a Run object that works for a 720-day idealized model run.

``` python
variables = ['olr', 'temp', 'sphum', 'ps']

idealized_moist_control = Run(
    name='idealized_moist_control',
    description=(
        'A test case for using aospy + an idealized simulation.'
        ),
    direc_nc='/path/to/output',
    nc_dur=2,
    nc_start_yr=0,
    nc_end_yr=1,
    default_yr_range=(1,1),
    nc_dir_struc='one_dir',
    nc_files={v : '00000.1x20days.nc' for v in variables}
)
```

Ideally one would be able to specify the time ranges in units of days rather than years.  That's something we may want to work on in the future.  This would be important in a case where the period of analysis does not align well with multiples of 360 days.  (In this case it's OK since the period is days 361 to 720).
