### PR TITLE
Support for years < 1678; Fix idealized keyword argument in Run; Temporary fix to Overflow Error

### DIFF
--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -136,7 +136,7 @@ class CalcInterface(object):
         self.start_date = TimeManager.str_to_datetime(date_range[0])
         self.end_date = TimeManager.str_to_datetime(date_range[-1])
         tm = TimeManager(self.start_date, self.end_date, intvl_out)
-        self.date_range = tm.create_time_array()
+        self.date_range = tm.create_time_array() # What is this line for?
 
         self.start_date_xray = tm.apply_year_offset(self.start_date)
         self.end_date_xray = tm.apply_year_offset(self.end_date)
@@ -428,7 +428,10 @@ class Calc(object):
                                                           end_date, direc_nc))
         dmget(files)
         ds = []
+        print start_date
+        print end_date
         for file_ in files:
+            print file_
             test = xray.open_dataset(file_, decode_cf=False,
                                      drop_variables=['time_bounds', 'nv'])
             if start_date.year < 1678:

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -132,7 +132,7 @@ class CalcInterface(object):
         self.start_date = TimeManager.str_to_datetime(date_range[0])
         self.end_date = TimeManager.str_to_datetime(date_range[-1])
         tm = TimeManager(self.start_date, self.end_date, intvl_out)
-        self.date_range = tm.create_time_array() # What is this line for?
+        self.date_range = tm.create_time_array()
 
         self.start_date_xray = tm.apply_year_offset(self.start_date)
         self.end_date_xray = tm.apply_year_offset(self.end_date)
@@ -567,7 +567,8 @@ class Calc(object):
     def compute(self):
         """Perform all desired calculations on the data and save externally."""
         # Get results at each desired timestep and spatial point.
-        full_ts, dt = self._compute(self.start_date, self.end_date) # TROUBLE
+        # Here we need to provide file read-in dates (NOT xray dates)
+        full_ts, dt = self._compute(self.start_date, self.end_date)
         # Average within each year if time-defined.
         # (If we don't want to group by year def_time_cond = True)
         def_time_cond = ('av' in self.dtype_in_time or not self.def_time or
@@ -576,8 +577,9 @@ class Calc(object):
             full_ts = self._to_yearly_ts(full_ts, dt)
         # Vertically integrate if vertically defined and specified.
         if self.dtype_out_vert == 'vert_int' and self.var.def_vert:
+            # Here we need file read-in dates (NOT xray dates)
             dp = self._get_pressure_vals('dp', self.start_date,
-                                         self.end_date) # TROUBLE
+                                         self.end_date)
             full_ts = self._vert_int(full_ts, dp)
         # Apply time reduction methods and save.
         if self.def_time:

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -370,7 +370,7 @@ class Calc(object):
         # xray.open_mfdataset. The main reason I held off on using it here 
         # was that it opens a can of worms with regard to performance; we'd
         # need to add some logic to make sure the data were chunked in a
-        # reasonable (and logic to change the chunking if need be). 
+        # reasonable way (and logic to change the chunking if need be). 
         for file_ in paths:
             test = xray.open_dataset(file_, decode_cf=False,
                                      drop_variables=['time_bounds', 'nv',

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -508,6 +508,10 @@ class Calc(object):
             dt_by_year = len(arr.groupby('time.year'))
         else:
             dt_by_year = dt.groupby('time.year').sum('time')
+            # Convert from ns to days (prevent overflow)
+            dt_by_year.values = dt_by_year.values.astype('timedelta64[D]').astype('float')
+        # Convert from ns to days (prevent overflow)    
+        dt.values = dt.values.astype('timedelta64[D]').astype('float')    
         arr = arr*dt
         return arr.groupby('time.year').sum('time') / dt_by_year
 

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -507,11 +507,9 @@ class Calc(object):
         if isinstance(dt, int):
             dt_by_year = len(arr.groupby('time.year'))
         else:
-            dt_by_year = dt.groupby('time.year').sum('time')
             # Convert from ns to days (prevent overflow)
-            dt_by_year.values = dt_by_year.values.astype('timedelta64[D]').astype('float')
-        # Convert from ns to days (prevent overflow)    
-        dt.values = dt.values.astype('timedelta64[D]').astype('float')    
+            dt.values = dt.values.astype('timedelta64[D]').astype('float')
+            dt_by_year = dt.groupby('time.year').sum('time')
         arr = arr*dt
         return arr.groupby('time.year').sum('time') / dt_by_year
 

--- a/aospy/region.py
+++ b/aospy/region.py
@@ -94,6 +94,8 @@ class Region(object):
         data = self.mask_var_xray(data)
         reg_mask = self.make_mask_xray(data)
         weights = self.mask_var_xray(model.sfc_area)
+        #print(data['lat']) # Need to make sure coordinates align to decimal points.
+        #print(model.sfc_area['lat'])
         # Take the area average 
         avg = (data*model.sfc_area).sum('lat').sum('lon') / weights.sum('lat').sum('lon')
         return avg 

--- a/aospy/run.py
+++ b/aospy/run.py
@@ -18,7 +18,7 @@ class Run(object):
                  nc_dur=False, nc_start_date=False, nc_end_date=False,
                  nc_dir_struc='gfdl', nc_suffix=False, nc_files={},
                  default_date_range=False, ens_mem_prefix=False,
-                 ens_mem_ext=False, ens_mem_suffix=False, tags=()):
+                 ens_mem_ext=False, ens_mem_suffix=False, tags=(), idealized=False):
         """Instantiate a `Run` object."""
         self.name = name
         self.description = description
@@ -37,7 +37,7 @@ class Run(object):
             self.default_date_range = (self.nc_start_date, self.nc_end_date)
 
         self.tags = tags
-
+        self.idealized = idealized
         self.ens_mem_prefix = ens_mem_prefix
         self.ens_mem_ext = ens_mem_ext
         self.ens_mem_suffix = ens_mem_suffix

--- a/aospy/timedate.py
+++ b/aospy/timedate.py
@@ -63,8 +63,8 @@ class TimeManager(object):
 
     def create_time_array(self):
         """Create an xray.DataArray comprising the desired months."""
-        all_months = pd.date_range(start=self.start_date,
-                                   end=self.end_date, freq='M')
+        all_months = pd.date_range(start=self.apply_year_offset(self.start_date),
+                                   end=self.apply_year_offset(self.end_date), freq='M')
         time = xray.DataArray(all_months, dims=['time'])
         month_cond = self._construct_month_conditional(time, self.months)
         return time[month_cond]


### PR DESCRIPTION
Just a few small issues to address here:
1. Support for years < 1678 (see issue #11): changing the arguments of two function calls was all that was needed here. The main issue was that aospy was trying to construct filenames using the `self.start_date_xray` and `self.end_date_xray`.  These dates are meant to be used strictly for computation only.  For files we need to use the raw, user-provided `nc_start_date` and `nc_end_date`.  I don't think this should impact how aospy handles straightforward times, since in those cases the xray and nc dates are equivalent.  Now that I think of it, I also think that there is no reason why we shouldn't do the offset from year 1678 rather than 1900; it really makes no difference to the computation and offsetting from 1678 allows for the flexibility of a longer non-standard time series.  What do you think?
2. Fix `idealized` keyword argument in Run: here I needed to make sure that a `Run` could accept `idealized` as a keyword argument.  Ultimately I think given the way we do the averaging we can do away with it.  In a future pull-request I'll get rid of it entirely. 
3. Here I implement a temporary fix of the overflow problem I was having; see #17 for more discussion. 
