### PR TITLE
Apply time offset to instantaneous data upon load by Calc

### DIFF
--- a/aospy/__init__.py
+++ b/aospy/__init__.py
@@ -1,6 +1,6 @@
 """aospy: management, analysis, and plotting of gridded climate data."""
 from .__config__ import (user_path, LAT_STR, LON_STR, PFULL_STR, PHALF_STR,
-                         PLEVEL_STR, TIME_STR)
+                         PLEVEL_STR, TIME_STR, TIME_STR_IDEALIZED)
 from . import constants
 from .constants import Constant
 from . import numerics

--- a/aospy/timedate.py
+++ b/aospy/timedate.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import xray
 
+from . import TIME_STR
 
 class TimeManager(object):
     """Convert input time specifications into arrays of datetime objects."""
@@ -63,9 +64,11 @@ class TimeManager(object):
 
     def create_time_array(self):
         """Create an xray.DataArray comprising the desired months."""
-        all_months = pd.date_range(start=self.apply_year_offset(self.start_date),
-                                   end=self.apply_year_offset(self.end_date), freq='M')
-        time = xray.DataArray(all_months, dims=['time'])
+        all_months = pd.date_range(
+            start=self.apply_year_offset(self.start_date),
+            end=self.apply_year_offset(self.end_date), freq='M'
+        )
+        time = xray.DataArray(all_months, dims=[TIME_STR])
         month_cond = self._construct_month_conditional(time, self.months)
         return time[month_cond]
 
@@ -106,8 +109,8 @@ def _get_time(time, start_date, end_date, months, indices=False):
     by numpy datetime64 objects (i.e. the year is between 1678 and 2262).
     """
     inds = TimeManager._construct_month_conditional(time, months)
-    inds &= (time['time'] <= np.datetime64(end_date))
-    inds &= (time['time'] >= np.datetime64(start_date))
+    inds &= (time[TIME_STR] <= np.datetime64(end_date))
+    inds &= (time[TIME_STR] >= np.datetime64(start_date))
     if indices == 'only':
         return inds
     elif indices:


### PR DESCRIPTION
The previously identified mismatch between the nominal time durations and actual time array values of GFDL instantaneous model output is now corrected immediately upon load, rather than within individual functions.

This is applied automatically to instantaneous data; more care need to be applied in the future if e.g. isntantaneous data from other institutions lacks this issue, or if GFDL fixes it in the future.  The logic is also extremely simple; something more programmatic would be better in the long run.  But it works for now.
