### PR TITLE
Add 'one_dir_freq' file read-in option

### DIFF
--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -235,7 +235,7 @@ class Calc(object):
         # data_in_files may hold absolute or relative paths
         paths = []
         for nc in data_in_files:
-            full = '/'.join([data_in_direc, nc]).replace('//', '/')
+            full = os.path.join(data_in_direc, nc)
             if os.path.isfile(nc):
                 paths.append(nc)
             elif os.path.isfile(full):

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -215,6 +215,30 @@ class Calc(object):
 
         self.data_out = {}
 
+    def _get_input_data_paths_one_dir_freq(self, name, data_in_direc, n=0):
+        """Get the names of netCDF files when all in same directory.
+        Allow the use to specify the separate output frequencies.
+        """
+        if isinstance(self.data_in_files[n][self.intvl_in][name], str):
+            data_in_files = [self.data_in_files[n][self.intvl_in][name]]
+        else:
+            data_in_files = self.data_in_files[n][self.intvl_in][name]
+        # data_in_files may hold absolute or relative paths
+        paths = []
+        for nc in data_in_files:
+            full = '/'.join([data_in_direc, nc]).replace('//', '/')
+            if os.path.isfile(nc):
+                paths.append(nc)
+            elif os.path.isfile(full):
+                paths.append(full)
+            else:
+                print("Warning: specified netCDF file `{}` "
+                      "not found".format(nc))
+        # Remove duplicate entries.
+        files = list(set(paths))
+        files.sort()
+        return files
+
     def _get_input_data_paths_one_dir(self, name, data_in_direc, n=0):
         """Get the names of netCDF files when all in same directory."""
         if isinstance(self.data_in_files[n][name], str):
@@ -292,6 +316,15 @@ class Calc(object):
             if self.data_in_dir_struc[n] == 'one_dir':
                 try:
                     files = self._get_input_data_paths_one_dir(
+                        name, data_in_direc, n=n
+                    )
+                except KeyError:
+                    pass
+                else:
+                    break
+            elif self.data_in_dir_struc[n] == 'one_dir_freq':
+                try:
+                    files = self._get_input_data_paths_one_dir_freq(
                         name, data_in_direc, n=n
                     )
                 except KeyError:

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -215,36 +215,23 @@ class Calc(object):
 
         self.data_out = {}
 
-    def _get_input_data_paths_one_dir_freq(self, name, data_in_direc, n=0):
-        """Get the names of netCDF files when all in same directory.
-        Allow the use to specify the separate output frequencies.
-        """
-        if isinstance(self.data_in_files[n][self.intvl_in][name], str):
-            data_in_files = [self.data_in_files[n][self.intvl_in][name]]
-        else:
-            data_in_files = self.data_in_files[n][self.intvl_in][name]
-        # data_in_files may hold absolute or relative paths
-        paths = []
-        for nc in data_in_files:
-            full = '/'.join([data_in_direc, nc]).replace('//', '/')
-            if os.path.isfile(nc):
-                paths.append(nc)
-            elif os.path.isfile(full):
-                paths.append(full)
+    def _data_in_files_one_dir(self, name, n=0):
+        """Get the file names of the files in a single directory"""
+        if self.intvl_in in self.data_in_files[n]:
+            if isinstance(self.data_in_files[n][self.intvl_in][name], str):
+                data_in_files = [self.data_in_files[n][self.intvl_in][name]]
             else:
-                print("Warning: specified netCDF file `{}` "
-                      "not found".format(nc))
-        # Remove duplicate entries.
-        files = list(set(paths))
-        files.sort()
-        return files
+                data_in_files = self.data_in_files[n][self.intvl_in][name]
+        else:
+            if isinstance(self.data_in_files[n][name], str):
+                data_in_files = [self.data_in_files[n][name]]
+            else:
+                data_in_files = self.data_in_files[n][name]
+        return data_in_files
 
     def _get_input_data_paths_one_dir(self, name, data_in_direc, n=0):
         """Get the names of netCDF files when all in same directory."""
-        if isinstance(self.data_in_files[n][name], str):
-            data_in_files = [self.data_in_files[n][name]]
-        else:
-            data_in_files = self.data_in_files[n][name]
+        data_in_files = self._data_in_files_one_dir(name, n)
         # data_in_files may hold absolute or relative paths
         paths = []
         for nc in data_in_files:
@@ -316,15 +303,6 @@ class Calc(object):
             if self.data_in_dir_struc[n] == 'one_dir':
                 try:
                     files = self._get_input_data_paths_one_dir(
-                        name, data_in_direc, n=n
-                    )
-                except KeyError:
-                    pass
-                else:
-                    break
-            elif self.data_in_dir_struc[n] == 'one_dir_freq':
-                try:
-                    files = self._get_input_data_paths_one_dir_freq(
                         name, data_in_direc, n=n
                     )
                 except KeyError:

--- a/aospy/utils.py
+++ b/aospy/utils.py
@@ -1,7 +1,7 @@
 """aospy.utils: utility functions for the aospy module."""
 import warnings
 
-from finite_diff import FiniteDiff
+from infinite_diff import FiniteDiff
 import numpy as np
 import pandas as pd
 import xray


### PR DESCRIPTION
I recognize that we ultimately want to refactor this process out of `calc.py`, but I needed something along these lines for dealing with idealized model output.  The option I've added is called `'one_dir_freq'`.  It is a very slight modification of the existing `'one_dir'` option; however in this case I leverage the `intvl_in` attribute of Calc, much like the `'gfdl'` option to enable the user to specify a series of files with different output frequencies (e.g. monthly, daily, 3hr etc.).  

Here's how one uses it within a Run object:

``` python
control_T42 = Run(
    name='control_T42',
    description=(
        'Control case at T42 spectral resolution'
        ),
    data_in_direc='path/to/files',
    default_date_range=(start, end),
    data_in_dir_struc='one_dir_freq',
    data_in_files={'20-day': {v: '00000.1x20days.nc' for v in variables},
                   'daily': {v: '00000.1xday.nc' for v in variables},
                   '3-hourly': {v: '00000.8xday.nc' for v in variables}},
    idealized=True
)
```
