### PR TITLE
Relax np.any() condition in populating model grid attributes

### DIFF
--- a/aospy/model.py
+++ b/aospy/model.py
@@ -153,7 +153,7 @@ class Model(object):
         for name_int, names_ext in grid_attrs.items():
             for name in names_ext:
                 grid_attr = self._get_grid_attr(grid_objs, name)
-                if np.any(grid_attr):
+                if grid_attr is not None:
                     # Rename coordinates to aospy's internal names.
                     renamed_attrs = self._rename_coords(grid_attr)
                     setattr(self, name_int, renamed_attrs)

--- a/aospy/region.py
+++ b/aospy/region.py
@@ -45,7 +45,7 @@ class Region(object):
         try:
             land_mask = data.land_mask
         except:
-            return 1.
+            return 1. # S. Clark 2016-01-28: Aquaplanet models have no landmask
             # S. Hill 2015-10-14: Eventually aospy will have a built-in land
             # mask array that it can use in case the object doesn't have one
             # of its own.  For now the object /must/ have one.
@@ -56,7 +56,7 @@ class Region(object):
             return 1. - land_mask
         if do_land_mask in ('strict_land', 'strict_ocean'):
             raise NotImplementedError
-        return 1.
+        return 1
 
     @staticmethod
     def _sum_over_lat_lon(arr):

--- a/aospy/region.py
+++ b/aospy/region.py
@@ -47,6 +47,7 @@ class Region(object):
         try:
             land_mask = data.land_mask
         except:
+            return 1.
             # S. Hill 2015-10-14: Eventually aospy will have a built-in land
             # mask array that it can use in case the object doesn't have one
             # of its own.  For now the object /must/ have one.
@@ -57,7 +58,7 @@ class Region(object):
             return 1. - land_mask
         if do_land_mask in ('strict_land', 'strict_ocean'):
             raise NotImplementedError
-        return 1
+        return 1.
 
     @staticmethod
     def _sum_over_lat_lon(arr):

--- a/aospy/region.py
+++ b/aospy/region.py
@@ -45,7 +45,6 @@ class Region(object):
         try:
             land_mask = data.land_mask
         except:
-            return 1. # S. Clark 2016-01-28: Aquaplanet models have no landmask
             # S. Hill 2015-10-14: Eventually aospy will have a built-in land
             # mask array that it can use in case the object doesn't have one
             # of its own.  For now the object /must/ have one.


### PR DESCRIPTION
I forget, was there a particular reason we used `np.any()` here?  In certain configurations of the idealized moist model, `pk` is all zeros;  this causes `np.any()` to return `False`, and subsequently `pk` is dropped from the model object, which causes problems downstream.  I think a reasonable fix is to just check the attribute has no object associated with it (i.e. just relax the conditional statement a bit).
