### PR TITLE
Testing timedate.py

### DIFF
--- a/aospy/test/test_timedate.py
+++ b/aospy/test/test_timedate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Test suite for aospy.utils module."""
+"""Test suite for aospy.timedate module."""
 import sys
 import unittest
 
@@ -12,7 +12,6 @@ from aospy.timedate import TimeManager
 
 class AospyTimeManagerTestCase(unittest.TestCase):
     def setUp(self):
-#        self.tm = TimeManager()
         pass
 
     def tearDown(self):

--- a/aospy/test/test_timedate.py
+++ b/aospy/test/test_timedate.py
@@ -5,9 +5,11 @@ import unittest
 
 import numpy as np
 import xarray as xr
+import pandas as pd
 from datetime import datetime
 
 from aospy.timedate import TimeManager
+from aospy import TIME_STR
 
 
 class AospyTimeManagerTestCase(unittest.TestCase):
@@ -37,12 +39,60 @@ class TestTimeManager(AospyTimeManagerTestCase):
     def test_str_to_datetime(self):
         self.assertEqual(TimeManager.str_to_datetime('2000-01-01'),
                          datetime(2000, 1, 1))
+        self.assertEqual(TimeManager.str_to_datetime('2000-01-0199999'),
+                         datetime(2000, 1, 1))
 
     def test_apply_year_offset(self):
         self.assertEqual(TimeManager.apply_year_offset(datetime(1678, 1, 1)),
                          datetime(1678, 1, 1))
         self.assertEqual(TimeManager.apply_year_offset(datetime(1, 1, 1)),
                          datetime(1900, 1, 1))
+
+    def test_construct_month_conditional(self):
+        test = pd.date_range('2000-01-01', '2000-03-01', freq='M')
+        test = xr.DataArray(test, dims=['time'], coords=[test])
+        result_jan = TimeManager._construct_month_conditional(test, [1])
+        np.testing.assert_array_equal(result_jan, np.array([True, False]))
+
+        result_jan_feb = TimeManager._construct_month_conditional(test, [1, 2])
+        np.testing.assert_array_equal(result_jan_feb, np.array([True, True]))
+
+        result_march = TimeManager._construct_month_conditional(test, [3])
+        np.testing.assert_array_equal(result_march, np.array([False, False]))
+
+        # Test sub-monthly intervals
+        test = pd.date_range('1999-12-31 18:00:00', '2000-01-01 00:00:00',
+                             freq='6H')
+        test = xr.DataArray(test, dims=[TIME_STR])
+        result_jan = TimeManager._construct_month_conditional(test, [1])
+        np.testing.assert_array_equal(result_jan,
+                                      np.array([False, True]))
+
+        # Test wrap-around year
+        result_jd = TimeManager._construct_month_conditional(test, [1, 12])
+        np.testing.assert_array_equal(result_jd,
+                                      np.array([True, True]))
+
+        # Test month not in range
+        result_march = TimeManager._construct_month_conditional(test, [3])
+        np.testing.assert_array_equal(result_march,
+                                      np.array([False, False]))
+
+    def test_month_indices(self):
+        np.testing.assert_array_equal(TimeManager.month_indices('ann'),
+                                      range(1, 13))
+        np.testing.assert_array_equal(TimeManager.month_indices('jja'),
+                                      np.array([6, 7, 8]))
+        with self.assertRaises(RuntimeError):
+            TimeManager.month_indices('dfm')
+        with self.assertRaises(RuntimeError):
+            TimeManager.month_indices('j')
+        with self.assertRaises(RuntimeError):
+            TimeManager.month_indices('q')
+        self.assertEqual(TimeManager.month_indices('s'), [9])
+        np.testing.assert_array_equal(TimeManager.month_indices('djf'),
+                                      np.array([12, 1, 2]))
+        self.assertEqual(TimeManager.month_indices(12), [12])
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestTimeManager)

--- a/aospy/test/test_timedate.py
+++ b/aospy/test/test_timedate.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""Test suite for aospy.utils module."""
+import sys
+import unittest
+
+import numpy as np
+import xarray as xr
+from datetime import datetime
+
+from aospy.timedate import TimeManager
+
+
+class AospyTimeManagerTestCase(unittest.TestCase):
+    def setUp(self):
+#        self.tm = TimeManager()
+        pass
+
+    def tearDown(self):
+        pass
+
+
+class TestTimeManager(AospyTimeManagerTestCase):
+    def test_to_datetime_bool(self):
+        self.assertEqual(TimeManager.to_datetime(True), True)
+        self.assertEqual(TimeManager.to_datetime(False), False)
+
+    def test_to_datetime_datetime(self):
+        self.assertEqual(TimeManager.to_datetime(datetime(2000, 1, 1)),
+                         datetime(2000, 1, 1))
+
+    def test_to_datetime_year_only(self):
+        self.assertEqual(TimeManager.to_datetime(2000), datetime(2000, 1, 1))
+
+    def test_to_datetime_str(self):
+        self.assertEqual(TimeManager.to_datetime('2000-01-01'),
+                         datetime(2000, 1, 1))
+
+    def test_str_to_datetime(self):
+        self.assertEqual(TimeManager.str_to_datetime('2000-01-01'),
+                         datetime(2000, 1, 1))
+
+    def test_apply_year_offset(self):
+        self.assertEqual(TimeManager.apply_year_offset(datetime(1678, 1, 1)),
+                         datetime(1678, 1, 1))
+        self.assertEqual(TimeManager.apply_year_offset(datetime(1, 1, 1)),
+                         datetime(1900, 1, 1))
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestTimeManager)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/aospy/test/test_timedate.py
+++ b/aospy/test/test_timedate.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Test suite for aospy.timedate module."""
-import sys
 import unittest
 
 import numpy as np
@@ -50,7 +49,7 @@ class TestTimeManager(AospyTimeManagerTestCase):
 
     def test_construct_month_conditional(self):
         test = pd.date_range('2000-01-01', '2000-03-01', freq='M')
-        test = xr.DataArray(test, dims=['time'], coords=[test])
+        test = xr.DataArray(test, dims=[TIME_STR], coords=[test])
         result_jan = TimeManager._construct_month_conditional(test, [1])
         np.testing.assert_array_equal(result_jan, np.array([True, False]))
 

--- a/aospy/timedate.py
+++ b/aospy/timedate.py
@@ -44,11 +44,19 @@ class TimeManager(object):
         if isinstance(months, int):
             return [months]
         if months.lower() == 'ann':
-            return range(1, 13)
-        first_letter = 'jfmamjjasond'*2
+            return np.arange(1, 13)
+        first_letter = 'jfmamjjasond' * 2
         # Python indexing starts at 0; month indices start at 1 for January.
-        st_ind = first_letter.find(months.lower()) + 1
-        return range(st_ind, st_ind + len(months))
+        count = first_letter.count(months)
+        if (count == 0) or (count > 2):
+            message = ("The user must provide a unique pattern of consecutive "
+                       "first letters of months within '{}'. The provided "
+                       "string '{}' does not comply."
+                       "  For individual months use integers."
+                       "".format(first_letter, months))
+            raise RuntimeError(message)
+        st_ind = first_letter.find(months.lower())
+        return np.arange(st_ind, st_ind + len(months)) % 12 + 1
 
     def __init__(self, start_date, end_date, months):
         """Instantiate a TimeManager object."""


### PR DESCRIPTION
Because it was a somewhat low-hanging fruit and I wanted to get some practice writing tests, I added some tests for some of the TimeManager methods within `timedate.py`. 
- In doing so I noticed that `TimeManager.month_indices` would return `[12, 13, 14]` when provided `'djf'` as an argument.  I guess this didn't cause any issues downstream, but out of safety I modified the method a bit.  
- I also noticed that if a string was provided, as long as the first letter was in `'jfmamjjasondjfmamjjasond'`, then it would always return something (even if the input was ambiguous, e.g. `'j'`, or meaningless, e.g. `'jq'`, or a nonconsecutive set of months, e.g. `'jjam'`).  This was partly because `str.find(arg)` returns the index within `str` of the start of `arg` if `arg` is in the `str` and `-1` if `arg` is not in `str`.  I added some logic to raise a `RuntimeError` if an input could not be parsed properly. 

Eventually I'll get to testing `TimeManager.create_time_array()` and `timedate._get_time()`, but I wanted to address the small issues with `month_indices` first.  Let me know if you have any comments or issues with how I set up the tests or modified `month_indices`.  Thanks!
