### PR TITLE
Add test coverage for idealized model cases

### DIFF
--- a/aospy/test/test_objs/models.py
+++ b/aospy/test/test_objs/models.py
@@ -23,8 +23,8 @@ idealized_moist = Model(
     name='idealized_moist',
     grid_file_paths=(
         ('/archive/skc/idealized_moist_alb_T42/control_gaussian_T42/'
-         'gfdl.ncrc2-default-prod/1x0m720d_32pe/history/00000.1x20days.nc',
-         '/home/skc/inputdata/aquaplanet.land_mask.nc'),
+         'gfdl.ncrc2-default-prod/1x0m720d_32pe/history/00000.1x20days.nc'),
+        '/home/skc/inputdata/aquaplanet.land_mask.nc',
     ),
     runs=[runs.test_idealized_moist],
     default_runs=[runs.test_idealized_moist],

--- a/aospy/test/test_objs/models.py
+++ b/aospy/test/test_objs/models.py
@@ -17,3 +17,15 @@ am2 = Model(
     runs=[runs.test_am2],
     default_runs=[runs.test_am2]
 )
+
+
+idealized_moist = Model(
+    name='idealized_moist',
+    grid_file_paths=(
+        ('/archive/skc/idealized_moist_alb_T42/control_gaussian_T42/'
+         'gfdl.ncrc2-default-prod/1x0m720d_32pe/history/00000.1x20days.nc',
+         '/home/skc/inputdata/aquaplanet.land_mask.nc'),
+    ),
+    runs=[runs.test_idealized_moist],
+    default_runs=[runs.test_idealized_moist],
+)

--- a/aospy/test/test_objs/runs.py
+++ b/aospy/test/test_objs/runs.py
@@ -13,3 +13,16 @@ test_am2 = Run(
     data_in_end_date='0080-12-31',
     default_date_range=('0021-01-01', '0080-12-31')
 )
+
+
+test_idealized_moist = Run(
+    name='test_idealized_moist',
+    description=(
+        'Control case at T42 spectral resolution'
+    ),
+    data_in_direc='/archive/skc/idealized_moist_alb_T42/control_gaussian_T42/'
+                  'gfdl.ncrc2-default-prod/1x0m720d_32pe/history',
+    data_in_dir_struc='one_dir',
+    data_in_files={'20-day': {v: '00000.1x20days.nc'
+                              for v in ['olr', 'temp']}},
+)

--- a/aospy/test/test_objs/runs.py
+++ b/aospy/test/test_objs/runs.py
@@ -24,5 +24,5 @@ test_idealized_moist = Run(
                   'gfdl.ncrc2-default-prod/1x0m720d_32pe/history',
     data_in_dir_struc='one_dir',
     data_in_files={'20-day': {v: '00000.1x20days.nc'
-                              for v in ['olr', 'temp']}},
+                              for v in ['olr', 'temp', 'ps']}},
 )

--- a/aospy/test/test_roundtrip.py
+++ b/aospy/test/test_roundtrip.py
@@ -8,8 +8,8 @@ from os.path import isfile
 
 from aospy.calc import Calc, CalcInterface
 from test_objs.projects import aospy_test
-from test_objs.models import am2
-from test_objs.runs import test_am2
+from test_objs.models import am2, idealized_moist
+from test_objs.runs import test_am2, test_idealized_moist
 from test_objs.variables import olr, temp
 from test_objs.regions import nh, sahel, nh_ocean
 
@@ -20,137 +20,168 @@ skip_message = ('Model grid files cannot be located; note this '
                 'filesystems.')
 
 
-class AospyTestCase(unittest.TestCase):
+class AM2TestCase(unittest.TestCase):
     def setUp(self):
-        self.am2_olr_test_params = {'proj': aospy_test,
-                                    'model': am2,
-                                    'run': test_am2,
-                                    'var': olr,
-                                    'date_range': ('0021-01-01', '0080-12-31'),
-                                    'intvl_in': 'monthly',
-                                    'dtype_in_time': 'ts',
-                                    'dtype_in_vert': 'pressure',
-                                    'dtype_out_vert': False,
-                                    'level': False}
-        self.am2_temp_test_params = {'proj': aospy_test,
-                                     'model': am2,
-                                     'run': test_am2,
-                                     'var': temp,
-                                     'date_range': ('0021-01-01',
-                                                    '0080-12-31'),
-                                     'intvl_in': 'monthly',
-                                     'dtype_in_time': 'ts',
-                                     'level': False}
+        self.olr_test_params = {'proj': aospy_test,
+                                'model': am2,
+                                'run': test_am2,
+                                'var': olr,
+                                'date_range': ('0021-01-01', '0080-12-31'),
+                                'intvl_in': 'monthly',
+                                'dtype_in_time': 'ts',
+                                'dtype_in_vert': 'pressure',
+                                'dtype_out_vert': False,
+                                'level': False}
+        self.temp_test_params = {'proj': aospy_test,
+                                 'model': am2,
+                                 'run': test_am2,
+                                 'var': temp,
+                                 'date_range': ('0021-01-01',
+                                                '0080-12-31'),
+                                 'intvl_in': 'monthly',
+                                 'dtype_in_time': 'ts',
+                                 'level': False}
 
     def tearDown(self):
         pass
 
 
-class TestAospy(AospyTestCase):
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_annual_mean(self):
+@unittest.skipIf(not am2_files_exist, skip_message)
+class TestAM2(AM2TestCase):
+    def test_annual_mean(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='av',
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_annual_ts(self):
+    def test_annual_ts(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='ts',
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_seasonal_mean(self):
+    def test_seasonal_mean(self):
         calc_int = CalcInterface(intvl_out='djf',
                                  dtype_out_time='av',
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_seasonal_ts(self):
+    def test_seasonal_ts(self):
         calc_int = CalcInterface(intvl_out='djf',
                                  dtype_out_time='ts',
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_monthly_mean(self):
+    def test_monthly_mean(self):
         calc_int = CalcInterface(intvl_out=1,
                                  dtype_out_time='av',
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_monthly_ts(self):
+    def test_monthly_ts(self):
         calc_int = CalcInterface(intvl_out=1,
                                  dtype_out_time='ts',
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_simple_reg_av(self):
+    def test_simple_reg_av(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='reg.av',
                                  region={'nh': nh},
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_simple_reg_ts(self):
+    def test_simple_reg_ts(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='reg.ts',
                                  region={'nh': nh},
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_complex_reg_av(self):
+    def test_complex_reg_av(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='reg.av',
                                  region={'sahel': sahel},
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_ocean_reg_av(self):
+    def test_ocean_reg_av(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='reg.av',
                                  region={'nh_ocean': nh_ocean},
-                                 **self.am2_olr_test_params)
+                                 **self.olr_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_vert_int_pressure(self):
+    def test_vert_int_pressure(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='av',
                                  dtype_out_vert='vert_int',
                                  dtype_in_vert='pressure',
-                                 **self.am2_temp_test_params)
+                                 **self.temp_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
-    @unittest.skipIf(not am2_files_exist, skip_message)
-    def test_am2_vert_int_sigma(self):
+    def test_vert_int_sigma(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='av',
                                  dtype_out_vert='vert_int',
                                  dtype_in_vert='sigma',
-                                 **self.am2_temp_test_params)
+                                 **self.temp_test_params)
         calc = Calc(calc_int)
         calc.compute()
 
+
+class TestIdealized(TestAM2):
+    def setUp(self):
+        self.olr_test_params = {'proj': aospy_test,
+                                'model': idealized_moist,
+                                'run': test_idealized_moist,
+                                'var': olr,
+                                'date_range': ('0001-12-27', '0002-12-22'),
+                                'intvl_in': '20-day',
+                                'dtype_in_time': 'ts',
+                                'dtype_in_vert': 'pressure',
+                                'dtype_out_vert': False,
+                                'level': False}
+        self.temp_test_params = {'proj': aospy_test,
+                                 'model': idealized_moist,
+                                 'run': test_idealized_moist,
+                                 'var': temp,
+                                 'date_range': ('0001-12-27',
+                                                '0002-12-22'),
+                                 'intvl_in': '20-day',
+                                 'dtype_in_time': 'ts',
+                                 'level': False}
+
+    @unittest.skip('not valid in idealized moist model')
+    def test_seasonal_mean(self):
+        pass
+
+    @unittest.skip('not valid in idealized moist model')
+    def test_seasonal_ts(self):
+        pass
+
+    @unittest.skip('not valid in idealized moist model')
+    def test_monthly_mean(self):
+        pass
+
+    @unittest.skip('not valid in idealized moist model')
+    def test_monthly_ts(self):
+        pass
+
+    @unittest.skip('not valid in idealized moist model')
+    def test_vert_int_pressure(self):
+        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/aospy/test/test_roundtrip.py
+++ b/aospy/test/test_roundtrip.py
@@ -15,6 +15,8 @@ from test_objs.regions import nh, sahel, nh_ocean
 
 am2_files_exist = all([isfile(grid_file)
                        for grid_file in am2.grid_file_paths])
+idealized_files_exist = all([isfile(grid_file)
+                             for grid_file in idealized_moist.grid_file_paths])
 skip_message = ('Model grid files cannot be located; note this '
                 'test can only be completed on the GFDL '
                 'filesystems.')
@@ -141,6 +143,7 @@ class TestAM2(AM2TestCase):
         calc.compute()
 
 
+@unittest.skipIf(not idealized_files_exist, skip_message)
 class TestIdealized(TestAM2):
     def setUp(self):
         self.olr_test_params = {'proj': aospy_test,

--- a/aospy/test/test_roundtrip.py
+++ b/aospy/test/test_roundtrip.py
@@ -22,7 +22,8 @@ skip_message = ('Model grid files cannot be located; note this '
                 'filesystems.')
 
 
-class AM2TestCase(unittest.TestCase):
+@unittest.skipIf(not am2_files_exist, skip_message)
+class TestAM2(unittest.TestCase):
     def setUp(self):
         self.olr_test_params = {'proj': aospy_test,
                                 'model': am2,
@@ -47,9 +48,6 @@ class AM2TestCase(unittest.TestCase):
     def tearDown(self):
         pass
 
-
-@unittest.skipIf(not am2_files_exist, skip_message)
-class TestAM2(AM2TestCase):
     def test_annual_mean(self):
         calc_int = CalcInterface(intvl_out='ann',
                                  dtype_out_time='av',


### PR DESCRIPTION
This PR addresses the test items listed in #42 for cases run with the idealized moist model.  It is implemented in the style suggested by @spencerahill in #42; note some tests are not valid for the idealized model, which contains no seasonal cycle and no pressure level interpolation post-processing, so methods for testing capabilities related to those attributes are overridden and skipped.
