### PR TITLE
TEST Add test cases for AM3, HiRAM, and CMIP5 output

### DIFF
--- a/aospy/test/test_objs/models.py
+++ b/aospy/test/test_objs/models.py
@@ -1,3 +1,5 @@
+import os
+
 from aospy.model import Model
 import runs
 
@@ -28,4 +30,51 @@ idealized_moist = Model(
     ),
     runs=[runs.test_idealized_moist],
     default_runs=[runs.test_idealized_moist],
+)
+
+
+# Lifted from Spencer Hill's obj library
+am3 = Model(
+    name='am3',
+    grid_file_paths=(
+        ('/archive/Spencer.Hill/am3/am3clim_hurrell/gfdl.ncrc2-intel-prod-'
+         'openmp/pp/atmos/atmos.static.nc'),
+        ('/archive/Spencer.Hill/am3/am3clim_hurrell/gfdl.ncrc2-intel-prod-'
+         'openmp/pp/atmos/ts/monthly/1yr/atmos.198101-198112.ucomp.nc'),
+        ('/archive/Spencer.Hill/am3/am3clim_hurrell/gfdl.ncrc2-intel-prod-'
+         'openmp/pp/atmos_level/ts/monthly/1yr/'
+         'atmos_level.198101-198112.ucomp.nc')
+    ),
+    runs=[runs.test_am3],
+    default_runs=[runs.test_am3]
+)
+
+
+hiram = Model(
+    name='hiram',
+    grid_file_paths=(
+        '/archive/Yi.Ming/siena_201211/c180_hiram_clim/'
+        'gfdl.ncrc2-default-prod/'
+        'pp/atmos/atmos.static.nc',
+        '/archive/Yi.Ming/siena_201211/c180_hiram_clim/'
+        'gfdl.ncrc2-default-prod/'
+        'pp/atmos/ts/monthly/17yr/atmos.197901-199512.ucomp.nc'
+    ),
+    runs=[runs.test_hiram],
+)
+
+
+root_dir = '/archive/pcmdi/repo/CMIP5/output/'
+cesm1_cam5 = Model(
+    name='cesm1-cam5',
+    description='',
+    data_in_dir_struc='gfdl_repo',
+    data_in_direc=os.path.realpath(os.path.join(root_dir,
+                                                'NSF-DOE-NCAR/CESM1-CAM5')),
+    data_in_dur=30,
+    data_in_start_date=1979,
+    data_in_end_date=2008,
+    default_date_range=(1979, 2008),
+    runs=[runs.test_amip],
+    default_runs=False
 )

--- a/aospy/test/test_objs/projects.py
+++ b/aospy/test/test_objs/projects.py
@@ -4,5 +4,5 @@ import models
 
 aospy_test = Proj(
     name='aospy_test',
-    models=(models.am2,)
+    models=(models.am2, models.idealized_moist, models.am3)
 )

--- a/aospy/test/test_objs/runs.py
+++ b/aospy/test/test_objs/runs.py
@@ -26,3 +26,41 @@ test_idealized_moist = Run(
     data_in_files={'20-day': {v: '00000.1x20days.nc'
                               for v in ['olr', 'temp', 'ps']}},
 )
+
+
+test_am3 = Run(
+    name='hurrell_cont',
+    description='am3_hc from Spencer Hills obj library',
+    data_in_direc=('/archive/Spencer.Hill/am3/am3clim_hurrell/'
+                   'gfdl.ncrc2-intel-prod-openmp/pp'),
+    data_in_dur=1,
+    data_in_start_date=1980,
+    data_in_end_date=2010,
+    default_date_range=(1981, 2010)
+)
+
+
+test_hiram = Run(
+    name='cont',
+    description=(
+        '1981-2000 HadISST climatological annual cycle of SSTs '
+        'and sea ice repeated annually, with PD atmospheric composition.'
+        'hiram_cont from Spencer Hills obj library'
+    ),
+    data_in_dur=17,
+    data_in_start_date=1979,
+    data_in_end_date=1995,
+    default_date_range=(1979, 1995),
+    data_in_direc=('/archive/Yi.Ming/siena_201211/c180_hiram_clim/'
+                   'gfdl.ncrc2-default-prod/pp')
+)
+
+
+test_amip = Run(
+    name='amip',
+    description=('Atmosphere only'
+                 'amip from Spencer Hills obj library'),
+    data_in_direc='mon/atmos/Amon/r1i1p1',
+    data_in_dir_struc='gfdl_repo',
+    default_date_range=(1979, 2008),
+)

--- a/aospy/test/test_roundtrip.py
+++ b/aospy/test/test_roundtrip.py
@@ -246,14 +246,14 @@ class TestHiRAM(TestAM2):
                                  'dtype_in_time': 'ts',
                                  'level': False}
 
-    @unittest.skip(('could not immediately find a case with temperature'
-                    ' output on sigma levels in CMIP5 archive'))
+    @unittest.skip('no HiRAM output readily at hand exists on sigma levels')
     def test_vert_int_sigma(self):
         pass
 
 
 # cesm1_cam5 has no grid files so just use hiram's to test to skip
 @unittest.skipIf(not model_files_exist(hiram), skip_message)
+@unittest.expectedFailure
 class TestCMIP5(TestAM2):
     def setUp(self):
         self.olr_test_params = {'proj': aospy_test,
@@ -276,8 +276,8 @@ class TestCMIP5(TestAM2):
                                  'dtype_in_time': 'ts',
                                  'level': False}
 
-    @unittest.skip(('could not immediately find a case with temperature'
-                    ' output on sigma levels in CMIP5 archive'))
+    @unittest.skip(('This repo does not contain any output'
+                    ' on sigma levels.'))
     def test_vert_int_sigma(self):
         pass
 

--- a/aospy/test/test_roundtrip.py
+++ b/aospy/test/test_roundtrip.py
@@ -8,21 +8,35 @@ from os.path import isfile
 
 from aospy.calc import Calc, CalcInterface
 from test_objs.projects import aospy_test
-from test_objs.models import am2, idealized_moist
-from test_objs.runs import test_am2, test_idealized_moist
+from test_objs.models import am2, idealized_moist, am3, hiram, cesm1_cam5
+from test_objs.runs import (test_am2, test_idealized_moist, test_am3,
+                            test_hiram, test_amip)
 from test_objs.variables import olr, temp
 from test_objs.regions import nh, sahel, nh_ocean
 
-am2_files_exist = all([isfile(grid_file)
-                       for grid_file in am2.grid_file_paths])
-idealized_files_exist = all([isfile(grid_file)
-                             for grid_file in idealized_moist.grid_file_paths])
+
+def model_files_exist(model):
+    """Returns True if the grid files specified in the given model
+    can be found on the filesystem.
+
+    Parameters
+    ----------
+    model : Model
+        aospy Model object to check
+
+    Returns
+    -------
+    files_exist : bool
+        True if grid files in specified in model exist
+    """
+    return all([isfile(grid_file)
+                for grid_file in model.grid_file_paths])
 skip_message = ('Model grid files cannot be located; note this '
                 'test can only be completed on the GFDL '
                 'filesystems.')
 
 
-@unittest.skipIf(not am2_files_exist, skip_message)
+@unittest.skipIf(not model_files_exist(am2), skip_message)
 class TestAM2(unittest.TestCase):
     def setUp(self):
         self.olr_test_params = {'proj': aospy_test,
@@ -141,7 +155,7 @@ class TestAM2(unittest.TestCase):
         calc.compute()
 
 
-@unittest.skipIf(not idealized_files_exist, skip_message)
+@unittest.skipIf(not model_files_exist(idealized_moist), skip_message)
 class TestIdealized(TestAM2):
     def setUp(self):
         self.olr_test_params = {'proj': aospy_test,
@@ -183,6 +197,90 @@ class TestIdealized(TestAM2):
     @unittest.skip('not valid in idealized moist model')
     def test_vert_int_pressure(self):
         pass
+
+
+@unittest.skipIf(not model_files_exist(am3), skip_message)
+class TestAM3(TestAM2):
+    def setUp(self):
+        self.olr_test_params = {'proj': aospy_test,
+                                'model': am3,
+                                'run': test_am3,
+                                'var': olr,
+                                'date_range': ('1981-01-01', '2010-12-31'),
+                                'intvl_in': 'monthly',
+                                'dtype_in_time': 'ts',
+                                'dtype_in_vert': 'pressure',
+                                'dtype_out_vert': False,
+                                'level': False}
+        self.temp_test_params = {'proj': aospy_test,
+                                 'model': am3,
+                                 'run': test_am3,
+                                 'var': temp,
+                                 'date_range': ('1981-01-01',
+                                                '2010-12-31'),
+                                 'intvl_in': 'monthly',
+                                 'dtype_in_time': 'ts',
+                                 'level': False}
+
+
+@unittest.skipIf(not model_files_exist(hiram), skip_message)
+class TestHiRAM(TestAM2):
+    def setUp(self):
+        self.olr_test_params = {'proj': aospy_test,
+                                'model': hiram,
+                                'run': test_hiram,
+                                'var': olr,
+                                'date_range': ('1979-01-01', '1995-12-31'),
+                                'intvl_in': 'monthly',
+                                'dtype_in_time': 'ts',
+                                'dtype_in_vert': 'pressure',
+                                'dtype_out_vert': False,
+                                'level': False}
+        self.temp_test_params = {'proj': aospy_test,
+                                 'model': hiram,
+                                 'run': test_hiram,
+                                 'var': temp,
+                                 'date_range': ('1979-01-01',
+                                                '1995-12-31'),
+                                 'intvl_in': 'monthly',
+                                 'dtype_in_time': 'ts',
+                                 'level': False}
+
+    @unittest.skip(('could not immediately find a case with temperature'
+                    ' output on sigma levels in CMIP5 archive'))
+    def test_vert_int_sigma(self):
+        pass
+
+
+# cesm1_cam5 has no grid files so just use hiram's to test to skip
+@unittest.skipIf(not model_files_exist(hiram), skip_message)
+class TestCMIP5(TestAM2):
+    def setUp(self):
+        self.olr_test_params = {'proj': aospy_test,
+                                'model': cesm1_cam5,
+                                'run': test_amip,
+                                'var': olr,
+                                'date_range': ('1979-01-01', '2008-12-31'),
+                                'intvl_in': 'monthly',
+                                'dtype_in_time': 'ts',
+                                'dtype_in_vert': 'pressure',
+                                'dtype_out_vert': False,
+                                'level': False}
+        self.temp_test_params = {'proj': aospy_test,
+                                 'model': cesm1_cam5,
+                                 'run': test_amip,
+                                 'var': temp,
+                                 'date_range': ('1979-01-01',
+                                                '2008-12-31'),
+                                 'intvl_in': 'monthly',
+                                 'dtype_in_time': 'ts',
+                                 'level': False}
+
+    @unittest.skip(('could not immediately find a case with temperature'
+                    ' output on sigma levels in CMIP5 archive'))
+    def test_vert_int_sigma(self):
+        pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Addresses test operations suggested in #42 for AM3, HiRAM, and CMIP5 output.  Currently all CMIP5 tests fail, because no grid files are provided in the model objects.  @spencerahill when was the last time you used `aospy` on CMIP5 output?  Would you expect things to work, or might some modifications need to be made?  Might a simple fix be just to add some grid files?
