### PR TITLE
A quick fix to make dmget optional

### DIFF
--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -451,7 +451,10 @@ class Calc(object):
         # filesystem at the NOAA GFDL computing cluster, should be factored out
         # of this function.  A config setting or some other user input should
         # specify what method to call to access the files on the filesystem.
-        dmget(paths)
+        try:
+            dmget(paths)
+        except OSError:
+            pass
         ds_chunks = []
         vars_to_drop = ['time_bounds', 'nv', 'bnds',
                         'average_T1', 'average_T2']
@@ -834,7 +837,10 @@ class Calc(object):
         # tarfile 'append' mode won't overwrite the old file, which we want.
         # So open in 'read' mode, extract the file, and then delete it.
         # But 'read' mode throws OSError if file doesn't exist: make it first.
-        dmget([self.path_archive])
+        try:
+            dmget([self.path_archive])
+        except OSError:
+            pass
         with tarfile.open(self.path_archive, 'a') as tar:
             pass
         with tarfile.open(self.path_archive, 'r') as tar:
@@ -898,7 +904,10 @@ class Calc(object):
     def _load_from_archive(self, dtype_out_time, dtype_out_vert=False):
         """Load data save in tarball on archive file system."""
         path = os.path.join(self.dir_archive, 'data.tar')
-        dmget([path])
+        try:
+            dmget([path])
+        except OSError:
+            pass
         with tarfile.open(path, 'r') as data_tar:
             ds = xr.open_dataset(
                 data_tar.extractfile(self.file_name[dtype_out_time]),

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -451,10 +451,7 @@ class Calc(object):
         # filesystem at the NOAA GFDL computing cluster, should be factored out
         # of this function.  A config setting or some other user input should
         # specify what method to call to access the files on the filesystem.
-        try:
-            dmget(paths)
-        except OSError:
-            pass
+        dmget(paths)
         ds_chunks = []
         vars_to_drop = ['time_bounds', 'nv', 'bnds',
                         'average_T1', 'average_T2']
@@ -837,10 +834,7 @@ class Calc(object):
         # tarfile 'append' mode won't overwrite the old file, which we want.
         # So open in 'read' mode, extract the file, and then delete it.
         # But 'read' mode throws OSError if file doesn't exist: make it first.
-        try:
-            dmget([self.path_archive])
-        except OSError:
-            pass
+        dmget([self.path_archive])
         with tarfile.open(self.path_archive, 'a') as tar:
             pass
         with tarfile.open(self.path_archive, 'r') as tar:
@@ -904,10 +898,7 @@ class Calc(object):
     def _load_from_archive(self, dtype_out_time, dtype_out_vert=False):
         """Load data save in tarball on archive file system."""
         path = os.path.join(self.dir_archive, 'data.tar')
-        try:
-            dmget([path])
-        except OSError:
-            pass
+        dmget([path])
         with tarfile.open(path, 'r') as data_tar:
             ds = xr.open_dataset(
                 data_tar.extractfile(self.file_name[dtype_out_time]),

--- a/aospy/io.py
+++ b/aospy/io.py
@@ -1,9 +1,13 @@
 """io.py: utility methods used internally by aospy for input/output, etc."""
 import os
+import logging
 import string
 import subprocess
 
 import numpy as np
+
+
+logging.basicConfig(level=logging.INFO)
 
 
 def to_dup_list(x, n, single_to_list=True):
@@ -189,7 +193,10 @@ def data_in_name_gfdl(name, domain, data_type, intvl_type, data_yr,
 
 def dmget(files_list):
     """Call GFDL command 'dmget' to access archived files."""
-    subprocess.call(['dmget'] + files_list)
+    try:
+        subprocess.call(['dmget'] + files_list)
+    except OSError:
+        logging.warning('dmget command not found in this machine')
 
 
 def hsmget_nc(files_list):

--- a/aospy/test/test_io.py
+++ b/aospy/test/test_io.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""Test suite for aospy.io module."""
+import sys
+import unittest
+
+import aospy.io as io
+
+
+class AospyIOTestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+
+class TestUtils(AospyIOTestCase):
+    def test_dmget(self):
+        # For now this just test to make sure that dmget
+        # doesn't raise an exception if the command does not exist
+        # on the system.
+        io.dmget('/home/Spencer.Clark/archive/imr_skc/control/'
+                 'gfdl.ncrc3-default-repro/1/history/00010101.atmos_month.nc')
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())

--- a/aospy/test/test_io.py
+++ b/aospy/test/test_io.py
@@ -19,8 +19,8 @@ class TestIO(AospyIOTestCase):
         # For now this just test to make sure that dmget
         # doesn't raise an exception if the command does not exist
         # on the system.
-        io.dmget('/home/Spencer.Clark/archive/imr_skc/control/'
-                 'gfdl.ncrc3-default-repro/1/history/00010101.atmos_month.nc')
+        io.dmget(['/home/Spencer.Clark/archive/imr_skc/control/'
+                 'gfdl.ncrc3-default-repro/1/history/00010101.atmos_month.nc'])
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/aospy/test/test_io.py
+++ b/aospy/test/test_io.py
@@ -14,7 +14,7 @@ class AospyIOTestCase(unittest.TestCase):
         pass
 
 
-class TestUtils(AospyIOTestCase):
+class TestIO(AospyIOTestCase):
     def test_dmget(self):
         # For now this just test to make sure that dmget
         # doesn't raise an exception if the command does not exist


### PR DESCRIPTION
We will need to put more thought into this eventually on how to support different IO sequences for different modeling centers, but for now this should prevent errors due to a lack of a `dmget` command.
