### PR TITLE
Simplify tar logic

### DIFF
--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -666,9 +666,6 @@ class Calc(object):
         """Add the data to the tar file in tar_out_direc."""
         if not os.path.isdir(self.dir_tar_out):
             os.makedirs(self.dir_tar_out)
-        # tarfile 'append' mode won't overwrite the old file, which we want.
-        # So open in 'read' mode, extract the file, and then delete it.
-        # But 'read' mode throws OSError if file doesn't exist: make it first.
         utils.io.dmget([self.path_tar_out])
         with tarfile.open(self.path_tar_out, 'a') as tar:
             tar.add(self.path_out[dtype_out_time],

--- a/aospy/calc.py
+++ b/aospy/calc.py
@@ -671,24 +671,6 @@ class Calc(object):
         # But 'read' mode throws OSError if file doesn't exist: make it first.
         utils.io.dmget([self.path_tar_out])
         with tarfile.open(self.path_tar_out, 'a') as tar:
-            pass
-        with tarfile.open(self.path_tar_out, 'r') as tar:
-            old_data_path = os.path.join(self.dir_tar_out,
-                                         self.file_name[dtype_out_time])
-            try:
-                tar.extract(self.file_name[dtype_out_time],
-                            path=old_data_path)
-            except KeyError:
-                pass
-            else:
-                # The os module treats files on archive as non-empty
-                # directories, so can't use os.remove or os.rmdir.
-                shutil.rmtree(old_data_path)
-                subprocess.call([
-                    "tar", "--delete", "--file={}".format(self.path_tar_out),
-                    self.file_name[dtype_out_time]
-                ])
-        with tarfile.open(self.path_tar_out, 'a') as tar:
             tar.add(self.path_out[dtype_out_time],
                     arcname=self.file_name[dtype_out_time])
 


### PR DESCRIPTION
Closes #157 

I tried this out both locally and on the GFDL filesystem and *I think* things are working OK (I tried submitting a calculation twice, with two different regions, and the tar file on archive was updated appropriately).  What was the original rationale behind the extract / subprocess logic before?  Is there something important I'm missing?