### PR TITLE
Update ahead of change of 'item in ds' behavior in xarray v0.11

### DIFF
--- a/aospy/data_loader.py
+++ b/aospy/data_loader.py
@@ -176,7 +176,7 @@ def _prep_time_data(ds):
     """
     ds = times.ensure_time_as_dim(ds)
     ds, min_year, max_year = times.numpy_datetime_workaround_encode_cf(ds)
-    if TIME_BOUNDS_STR in ds:
+    if TIME_BOUNDS_STR in ds.coords:
         ds = times.ensure_time_avg_has_cf_metadata(ds)
         ds[TIME_STR] = times.average_time_bounds(ds)
     else:

--- a/aospy/test/test_data_loader.py
+++ b/aospy/test/test_data_loader.py
@@ -81,14 +81,14 @@ class AospyDataLoaderTestCase(unittest.TestCase):
 
 class TestDataLoader(AospyDataLoaderTestCase):
     def test_rename_grid_attrs_ds(self):
-        assert LAT_STR not in self.ds
-        assert self.ALT_LAT_STR in self.ds
+        assert LAT_STR not in self.ds.coords
+        assert self.ALT_LAT_STR in self.ds.coords
         ds = grid_attrs_to_aospy_names(self.ds)
-        assert LAT_STR in ds
+        assert LAT_STR in ds.coords
 
     def test_rename_grid_attrs_dim_no_coord(self):
         bounds_dim = 'nv'
-        assert bounds_dim not in self.ds
+        assert bounds_dim not in self.ds.coords
         assert bounds_dim in GRID_ATTRS[BOUNDS_STR]
         # Create DataArray with all dims lacking coords
         values = self.ds[self.var_name].values
@@ -101,7 +101,7 @@ class TestDataLoader(AospyDataLoaderTestCase):
 
     def test_rename_grid_attrs_skip_scalar_dim(self):
         phalf_dim = 'phalf'
-        assert phalf_dim not in self.ds
+        assert phalf_dim not in self.ds.coords
         assert phalf_dim in GRID_ATTRS[PHALF_STR]
         ds = self.ds.copy()
         ds[phalf_dim] = 4
@@ -167,9 +167,9 @@ class TestDataLoader(AospyDataLoaderTestCase):
             self.DataLoader._generate_file_set()
 
     def test_prep_time_data(self):
-        assert (TIME_WEIGHTS_STR not in self.inst_ds)
+        assert (TIME_WEIGHTS_STR not in self.inst_ds.coords)
         ds, min_year, max_year = _prep_time_data(self.inst_ds)
-        assert (TIME_WEIGHTS_STR in ds)
+        assert (TIME_WEIGHTS_STR in ds.coords)
         self.assertEqual(min_year, 2000)
         self.assertEqual(max_year, 2000)
 
@@ -182,9 +182,9 @@ class TestDataLoader(AospyDataLoaderTestCase):
             ds.attrs['a'] = 'b'
             return ds
 
-        assert LAT_STR not in self.ds
-        assert self.ALT_LAT_STR in self.ds
-        assert LON_STR in self.ds
+        assert LAT_STR not in self.ds.coords
+        assert self.ALT_LAT_STR in self.ds.coords
+        assert LON_STR in self.ds.coords
 
         expected = self.ds.rename({self.ALT_LAT_STR: LAT_STR})
         expected = expected.set_coords(TIME_BOUNDS_STR)

--- a/aospy/utils/times.py
+++ b/aospy/utils/times.py
@@ -286,7 +286,7 @@ def numpy_datetime_workaround_encode_cf(ds):
         new_units = units.replace(units_yr, str(new_units_yr))
 
         for VAR_STR in TIME_VAR_STRS:
-            if VAR_STR in ds:
+            if VAR_STR in ds.coords:
                 var = ds[VAR_STR]
                 var.attrs['units'] = new_units
         return ds, min_yr, max_yr
@@ -409,7 +409,7 @@ def ensure_time_avg_has_cf_metadata(ds):
     Dataset or DataArray
         Time average metadata attributes added if needed.
     """  # flake8: noqa
-    if TIME_WEIGHTS_STR not in ds:
+    if TIME_WEIGHTS_STR not in ds.coords:
         time_weights = ds[TIME_BOUNDS_STR].diff(BOUNDS_STR)
         time_weights = time_weights.rename(TIME_WEIGHTS_STR).squeeze()
         ds[TIME_WEIGHTS_STR] = time_weights.drop(BOUNDS_STR)


### PR DESCRIPTION
Just updated to xarray v0.10 and started getting a lot of deprecation warnings when running aospy due to https://github.com/pydata/xarray/pull/1645, c.f. https://github.com/pydata/xarray/issues/1267.  So I tried to find it everywhere this comes up and fix it.

@spencerkclark let me know if you see any reason why we shouldn't do this, or if I missed anything.